### PR TITLE
Validate machine config initial and transitions

### DIFF
--- a/src/machine_validator.erl
+++ b/src/machine_validator.erl
@@ -5,7 +5,8 @@
     validate_machine_alphabet/1,
     validate_machine_states/1,
     validate_machine_blank/2,
-    validate_machine_finals/2
+    validate_machine_finals/2,
+    validate_machine_initial/2
 ]).
 -else.
 -export([]).
@@ -70,4 +71,15 @@ validate_machine_finals(Finals, States, expected_states_step) ->
             ok;
         EveryFinalsEntryIsStatesEntry =:= false ->
             {error, {expected_states, FinalsLessStates}}
+    end.
+
+validate_machine_initial(Initial, States) ->
+    InitialIsStatesMember = lists:member(Initial, States),
+    if
+        InitialIsStatesMember =:= true ->
+            ok;
+        InitialIsStatesMember =:= false ->
+            {
+                error, {expected_states, Initial}
+            }
     end.

--- a/src/machine_validator.erl
+++ b/src/machine_validator.erl
@@ -168,7 +168,7 @@ validation_step_not_alphabet_read_write_transitions(TransitionsMap, States, Alph
         {error, State, Error} -> {error, State, Error}
     end.
 
-% % 3/ Validate each key states and to_state from states
+% 3/ Validate each key states and to_state from states
 verify_to_state_transition(Transition, States) ->
     ToState = Transition#parsed_machine_config_transition.to_state,
     Result = is_valid_state(ToState, States),

--- a/src/parser.erl
+++ b/src/parser.erl
@@ -158,6 +158,7 @@ parse_machine_transitions(_) ->
     {error, invalid}.
 
 iterate_on_machine_states_transitions_map(Iterator) ->
+    % TODO Below could fail and is not protected at all
     {State, Transitions, NextIterator} = maps:next(Iterator),
     iterate_on_machine_states_transitions_map(NextIterator, State, Transitions, #{}).
 iterate_on_machine_states_transitions_map(_Iterator, <<"">>, _Transitions, _ParsedTransitionMap) ->
@@ -269,61 +270,144 @@ to_pretty_value(Value) -> binary_to_list(jsone:encode(Value)).
 
 get_rules_for_name_field() -> "a machine must have a name of at least one character".
 
-get_rules_for_alphabet_field() -> "a machine must have a non-empty alphabet, made of strings with exactly one character".
+get_rules_for_alphabet_field() ->
+    "a machine must have a non-empty alphabet, made of strings with exactly one character".
 
-get_rules_for_blank_field() -> "a machine must have a blank character exactly made of one character".
+get_rules_for_blank_field() ->
+    "a machine must have a blank character exactly made of one character".
 
 get_rules_for_initial_state_field() -> "a machine must have a non-empty initial state".
 
-get_rules_for_states_field() -> "a machine must have a non-empty list of states, which must all be non-empty strings".
+get_rules_for_states_field() ->
+    "a machine must have a non-empty list of states, which must all be non-empty strings".
 
-get_rules_for_finals_field() -> "a machine must have a list of states (optionally empty), which must all be non-empty strings".
+get_rules_for_finals_field() ->
+    "a machine must have a list of states (optionally empty), which must all be non-empty strings".
 
-get_transition_information_for_error_formatting(State, TransitionIndex) -> "transition " ++ to_pretty_value(TransitionIndex) ++ " for state " ++ State.
+get_transition_information_for_error_formatting(State, TransitionIndex) ->
+    "transition " ++ to_pretty_value(TransitionIndex) ++ " for state " ++ State.
 
-get_rules_for_transitions_field_read_property() -> "each transition must have a read property that is a string with exactly one character".
+get_rules_for_transitions_field_read_property() ->
+    "each transition must have a read property that is a string with exactly one character".
 
-get_rules_for_transitions_field_write_property() -> "each transition must have a write property that is a string with exactly one character".
+get_rules_for_transitions_field_write_property() ->
+    "each transition must have a write property that is a string with exactly one character".
 
-get_rules_for_transitions_field_to_state_property() -> "each transition must have a to_state property that is a non-empty string".
+get_rules_for_transitions_field_to_state_property() ->
+    "each transition must have a to_state property that is a non-empty string".
 
-get_rules_for_transitions_field_action_property() -> "each transition must have an action property that is either \"LEFT\" OR \"RIGHT\"".
+get_rules_for_transitions_field_action_property() ->
+    "each transition must have an action property that is either \"LEFT\" OR \"RIGHT\"".
 
-format_error({name, empty}) -> "machine name is empty; " ++ get_rules_for_name_field();
-format_error({name, {expected_bitstring, Name}}) -> "machine name is not a string (received: " ++ to_pretty_value(Name) ++ "); " ++ get_rules_for_name_field();
-format_error({name, invalid}) -> "machine has no name; " ++ get_rules_for_name_field();
-format_error({alphabet, no_entry}) -> "machine has no alphabet; " ++ get_rules_for_alphabet_field();
-format_error({alphabet, empty_list}) -> "machine alphabet is empty; " ++ get_rules_for_alphabet_field();
-format_error({alphabet, empty_alphabet_character}) -> "machine alphabet contains an empty character; " ++ get_rules_for_alphabet_field();
-format_error({alphabet, {expected_bitstring, Character}}) -> "machine alphabet contains a value that is not a string (received: " ++ to_pretty_value(Character) ++ "); " ++ get_rules_for_alphabet_field();
-format_error({alphabet, {too_long_alphabet_character, Character}}) -> "machine alphabet contains a value that is too long (received: " ++ Character ++ "); " ++ get_rules_for_alphabet_field();
-format_error({blank, empty_alphabet_character}) -> "machine blank character is empty; " ++ get_rules_for_blank_field();
-format_error({blank, {expected_bitstring, Blank}}) -> "machine blank character is not a string (received: " ++ to_pretty_value(Blank) ++ "); " ++ get_rules_for_blank_field();
-format_error({blank, invalid}) -> "machine has no blank character; " ++ get_rules_for_blank_field();
-format_error({blank, {too_long_alphabet_character, Blank}}) -> "machine blank character is too long (received: " ++ Blank ++ "); " ++ get_rules_for_blank_field();
-format_error({initial, {expected_bitstring, InitialState}}) -> "machine initial state is not a string (received: " ++ to_pretty_value(InitialState) ++ "); " ++ get_rules_for_initial_state_field();
-format_error({initial, invalid}) -> "machine has no initial state; " ++ get_rules_for_initial_state_field();
-format_error({initial, empty_state}) -> "machine initial state is empty; " ++ get_rules_for_initial_state_field();
-format_error({states, {expected_bitstring, State}}) -> "machine has a state that is not a string (" ++ to_pretty_value(State) ++ "); " ++ get_rules_for_states_field();
-format_error({states, empty_state}) -> "machine has an empty state; " ++ get_rules_for_states_field();
-format_error({states, invalid}) -> "machine has no states; " ++ get_rules_for_states_field();
-format_error({states, empty_list}) -> "machine has an empty list of states; " ++ get_rules_for_states_field();
-format_error({finals, {expected_bitstring, State}}) -> "machine has a final state that is not a string (" ++ to_pretty_value(State) ++ "); " ++ get_rules_for_finals_field();
-format_error({finals, empty_state}) -> "machine has an empty final state; " ++ get_rules_for_finals_field();
-format_error({finals, invalid}) -> "machine has no final states; " ++ get_rules_for_finals_field();
-format_error({transitions, invalid}) -> "machine has an empty transitions object; a machine must contain at least one transition";
-format_error({transitions, empty_state_key}) -> "machine contains transitions for a state that is an empty string; a machine can only contain transitions for valid states, which must be non-empty strings";
-format_error({transitions, {expected_state_bitstring, State}}) -> "machine contains transitions for a state that is not a valid string (" ++ to_pretty_value(State) ++ "); a machine can only contain transitions for valid states, which must be non-empty strings";
-format_error({transitions, {State, TransitionIndex, read, empty_alphabet_character}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " has its read property that is empty; " ++ get_rules_for_transitions_field_read_property();
-format_error({transitions, {State, TransitionIndex, read, {expected_bitstring, ReadValue}}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " has its read property that is not a string (" ++ to_pretty_value(ReadValue) ++ "); " ++ get_rules_for_transitions_field_read_property();
-format_error({transitions, {State, TransitionIndex, read, {too_long_alphabet_character, ReadValue}}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " has its read property that is too long (" ++ ReadValue ++ "); " ++ get_rules_for_transitions_field_read_property();
-format_error({transitions, {State, TransitionIndex, read, no_entry}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " does not have a read property; " ++ get_rules_for_transitions_field_read_property();
-format_error({transitions, {State, TransitionIndex, write, empty_alphabet_character}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " has its write property that is empty; " ++ get_rules_for_transitions_field_write_property();
-format_error({transitions, {State, TransitionIndex, write, {expected_bitstring, ReadValue}}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " has its write property that is not a string (" ++ to_pretty_value(ReadValue) ++ "); " ++ get_rules_for_transitions_field_write_property();
-format_error({transitions, {State, TransitionIndex, write, {too_long_alphabet_character, ReadValue}}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " has its write property that is too long (" ++ ReadValue ++ "); " ++ get_rules_for_transitions_field_write_property();
-format_error({transitions, {State, TransitionIndex, write, no_entry}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " does not have a write property; " ++ get_rules_for_transitions_field_write_property();
-format_error({transitions, {State, TransitionIndex, to_state, {expected_bitstring, ToStateValue}}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " has its to_state property that is not a string (" ++ to_pretty_value(ToStateValue) ++ "); " ++ get_rules_for_transitions_field_to_state_property();
-format_error({transitions, {State, TransitionIndex, to_state, no_entry}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " does not have a to_state property; " ++ get_rules_for_transitions_field_to_state_property();
-format_error({transitions, {State, TransitionIndex, to_state, empty_state}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " has its to_state property that is empty; " ++ get_rules_for_transitions_field_to_state_property();
-format_error({transitions, {State, TransitionIndex, action, {unknown_action, ActionValue}}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " has an unknown action property (" ++ to_pretty_value(ActionValue) ++ "); " ++ get_rules_for_transitions_field_action_property();
-format_error({transitions, {State, TransitionIndex, action, no_entry}}) -> get_transition_information_for_error_formatting(State, TransitionIndex) ++ " does not have an action property; " ++ get_rules_for_transitions_field_action_property().
+format_error({name, empty}) ->
+    "machine name is empty; " ++ get_rules_for_name_field();
+format_error({name, {expected_bitstring, Name}}) ->
+    "machine name is not a string (received: " ++ to_pretty_value(Name) ++ "); " ++
+        get_rules_for_name_field();
+format_error({name, invalid}) ->
+    "machine has no name; " ++ get_rules_for_name_field();
+format_error({alphabet, no_entry}) ->
+    "machine has no alphabet; " ++ get_rules_for_alphabet_field();
+format_error({alphabet, empty_list}) ->
+    "machine alphabet is empty; " ++ get_rules_for_alphabet_field();
+format_error({alphabet, empty_alphabet_character}) ->
+    "machine alphabet contains an empty character; " ++ get_rules_for_alphabet_field();
+format_error({alphabet, {expected_bitstring, Character}}) ->
+    "machine alphabet contains a value that is not a string (received: " ++
+        to_pretty_value(Character) ++ "); " ++ get_rules_for_alphabet_field();
+format_error({alphabet, {too_long_alphabet_character, Character}}) ->
+    "machine alphabet contains a value that is too long (received: " ++ Character ++ "); " ++
+        get_rules_for_alphabet_field();
+format_error({blank, empty_alphabet_character}) ->
+    "machine blank character is empty; " ++ get_rules_for_blank_field();
+format_error({blank, {expected_bitstring, Blank}}) ->
+    "machine blank character is not a string (received: " ++ to_pretty_value(Blank) ++ "); " ++
+        get_rules_for_blank_field();
+format_error({blank, invalid}) ->
+    "machine has no blank character; " ++ get_rules_for_blank_field();
+format_error({blank, {too_long_alphabet_character, Blank}}) ->
+    "machine blank character is too long (received: " ++ Blank ++ "); " ++
+        get_rules_for_blank_field();
+format_error({initial, {expected_bitstring, InitialState}}) ->
+    "machine initial state is not a string (received: " ++ to_pretty_value(InitialState) ++ "); " ++
+        get_rules_for_initial_state_field();
+format_error({initial, invalid}) ->
+    "machine has no initial state; " ++ get_rules_for_initial_state_field();
+format_error({initial, empty_state}) ->
+    "machine initial state is empty; " ++ get_rules_for_initial_state_field();
+format_error({states, {expected_bitstring, State}}) ->
+    "machine has a state that is not a string (" ++ to_pretty_value(State) ++ "); " ++
+        get_rules_for_states_field();
+format_error({states, empty_state}) ->
+    "machine has an empty state; " ++ get_rules_for_states_field();
+format_error({states, invalid}) ->
+    "machine has no states; " ++ get_rules_for_states_field();
+format_error({states, empty_list}) ->
+    "machine has an empty list of states; " ++ get_rules_for_states_field();
+format_error({finals, {expected_bitstring, State}}) ->
+    "machine has a final state that is not a string (" ++ to_pretty_value(State) ++ "); " ++
+        get_rules_for_finals_field();
+format_error({finals, empty_state}) ->
+    "machine has an empty final state; " ++ get_rules_for_finals_field();
+format_error({finals, invalid}) ->
+    "machine has no final states; " ++ get_rules_for_finals_field();
+format_error({transitions, invalid}) ->
+    "machine has an empty transitions object; a machine must contain at least one transition";
+format_error({transitions, empty_state_key}) ->
+    "machine contains transitions for a state that is an empty string; a machine can only contain transitions for valid states, which must be non-empty strings";
+format_error({transitions, {expected_state_bitstring, State}}) ->
+    "machine contains transitions for a state that is not a valid string (" ++
+        to_pretty_value(State) ++
+        "); a machine can only contain transitions for valid states, which must be non-empty strings";
+format_error({transitions, {State, TransitionIndex, read, empty_alphabet_character}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " has its read property that is empty; " ++ get_rules_for_transitions_field_read_property();
+format_error({transitions, {State, TransitionIndex, read, {expected_bitstring, ReadValue}}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " has its read property that is not a string (" ++ to_pretty_value(ReadValue) ++ "); " ++
+        get_rules_for_transitions_field_read_property();
+format_error(
+    {transitions, {State, TransitionIndex, read, {too_long_alphabet_character, ReadValue}}}
+) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " has its read property that is too long (" ++ ReadValue ++ "); " ++
+        get_rules_for_transitions_field_read_property();
+format_error({transitions, {State, TransitionIndex, read, no_entry}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " does not have a read property; " ++ get_rules_for_transitions_field_read_property();
+format_error({transitions, {State, TransitionIndex, write, empty_alphabet_character}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " has its write property that is empty; " ++
+        get_rules_for_transitions_field_write_property();
+format_error({transitions, {State, TransitionIndex, write, {expected_bitstring, ReadValue}}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " has its write property that is not a string (" ++ to_pretty_value(ReadValue) ++ "); " ++
+        get_rules_for_transitions_field_write_property();
+format_error(
+    {transitions, {State, TransitionIndex, write, {too_long_alphabet_character, ReadValue}}}
+) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " has its write property that is too long (" ++ ReadValue ++ "); " ++
+        get_rules_for_transitions_field_write_property();
+format_error({transitions, {State, TransitionIndex, write, no_entry}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " does not have a write property; " ++ get_rules_for_transitions_field_write_property();
+format_error({transitions, {State, TransitionIndex, to_state, {expected_bitstring, ToStateValue}}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " has its to_state property that is not a string (" ++ to_pretty_value(ToStateValue) ++
+        "); " ++ get_rules_for_transitions_field_to_state_property();
+format_error({transitions, {State, TransitionIndex, to_state, no_entry}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " does not have a to_state property; " ++
+        get_rules_for_transitions_field_to_state_property();
+format_error({transitions, {State, TransitionIndex, to_state, empty_state}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " has its to_state property that is empty; " ++
+        get_rules_for_transitions_field_to_state_property();
+format_error({transitions, {State, TransitionIndex, action, {unknown_action, ActionValue}}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " has an unknown action property (" ++ to_pretty_value(ActionValue) ++ "); " ++
+        get_rules_for_transitions_field_action_property();
+format_error({transitions, {State, TransitionIndex, action, no_entry}}) ->
+    get_transition_information_for_error_formatting(State, TransitionIndex) ++
+        " does not have an action property; " ++ get_rules_for_transitions_field_action_property().

--- a/src/turing.erl
+++ b/src/turing.erl
@@ -67,9 +67,8 @@ decode_raw_machine_config(BinaryFile) ->
 parse_decoded_machine_config(DecodedMachineConfig) ->
     ParsedMachineResult = parser:parse_machine(DecodedMachineConfig),
     case ParsedMachineResult of
-        {error, _Error} ->
-            % parser:format_error(error, Error);
-            io:format("Parser error");
+        {error, Error} ->
+            parser:format_error(error, Error);
         {ok, ParsedMachineConfig} ->
             % Will change in the future
             start_machine(ParsedMachineConfig)

--- a/test/machine_validator_test.erl
+++ b/test/machine_validator_test.erl
@@ -23,7 +23,7 @@ get_valid_states() ->
 
 get_valid_transitions_map() ->
     #{
-        "abs" => [
+        "scanright" => [
             #parsed_machine_config_transition{
                 read = ".",
                 to_state = "scanright",
@@ -31,27 +31,27 @@ get_valid_transitions_map() ->
                 action = right
             },
             #parsed_machine_config_transition{
-                read = "?",
-                to_state = "cocorico",
-                write = "*",
+                read = "=",
+                to_state = "skip",
+                write = "-",
                 action = left
             }
         ],
-        "add" => [
+        "eraseone" => [
             #parsed_machine_config_transition{
                 read = ".",
-                to_state = "scanright",
+                to_state = "HALT",
                 write = ".",
                 action = right
             },
             #parsed_machine_config_transition{
-                read = "?",
-                to_state = "cocorico",
-                write = "*",
+                read = "-",
+                to_state = "eraseone",
+                write = "=",
                 action = left
             }
         ],
-        "sub" => [
+        "subone" => [
             #parsed_machine_config_transition{
                 read = ".",
                 to_state = "scanright",
@@ -59,9 +59,9 @@ get_valid_transitions_map() ->
                 action = right
             },
             #parsed_machine_config_transition{
-                read = "?",
-                to_state = "cocorico",
-                write = "*",
+                read = "-",
+                to_state = "subone",
+                write = ".",
                 action = left
             }
         ]
@@ -136,9 +136,9 @@ validate_machine_transitions_test() ->
     ).
 
 validate_machine_transitions_duplicated_error_test() ->
-    {error, "sub", {duplicated_elements, ["."]}} = machine_validator:validate_machine_transitions(
+    {error, "subone", {duplicated_elements, ["."]}} = machine_validator:validate_machine_transitions(
         #{
-            "abs" => [
+            "skip" => [
                 #parsed_machine_config_transition{
                     read = ".",
                     to_state = "scanright",
@@ -146,13 +146,13 @@ validate_machine_transitions_duplicated_error_test() ->
                     action = right
                 },
                 #parsed_machine_config_transition{
-                    read = "?",
-                    to_state = "cocorico",
-                    write = "*",
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
                     action = left
                 }
             ],
-            "add" => [
+            "scanright" => [
                 #parsed_machine_config_transition{
                     read = ".",
                     to_state = "scanright",
@@ -160,13 +160,13 @@ validate_machine_transitions_duplicated_error_test() ->
                     action = right
                 },
                 #parsed_machine_config_transition{
-                    read = "?",
-                    to_state = "cocorico",
-                    write = "*",
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
                     action = left
                 }
             ],
-            "sub" => [
+            "subone" => [
                 #parsed_machine_config_transition{
                     read = ".",
                     to_state = "scanright",
@@ -180,9 +180,9 @@ validate_machine_transitions_duplicated_error_test() ->
                     action = right
                 },
                 #parsed_machine_config_transition{
-                    read = "?",
-                    to_state = "cocorico",
-                    write = "*",
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
                     action = left
                 }
             ]
@@ -192,9 +192,9 @@ validate_machine_transitions_duplicated_error_test() ->
     ).
 
 validate_machine_transitions_several_duplicated_error_test() ->
-    {error, "add", {duplicated_elements, [".", "?"]}} = machine_validator:validate_machine_transitions(
+    {error, "scanright", {duplicated_elements, [".", "-"]}} = machine_validator:validate_machine_transitions(
         #{
-            "abs" => [
+            "skip" => [
                 #parsed_machine_config_transition{
                     read = ".",
                     to_state = "scanright",
@@ -202,13 +202,13 @@ validate_machine_transitions_several_duplicated_error_test() ->
                     action = right
                 },
                 #parsed_machine_config_transition{
-                    read = "?",
-                    to_state = "cocorico",
-                    write = "*",
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
                     action = left
                 }
             ],
-            "add" => [
+            "scanright" => [
                 #parsed_machine_config_transition{
                     read = ".",
                     to_state = "scanright",
@@ -222,19 +222,19 @@ validate_machine_transitions_several_duplicated_error_test() ->
                     action = right
                 },
                 #parsed_machine_config_transition{
-                    read = "?",
-                    to_state = "cocorico",
-                    write = "*",
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
                     action = left
                 },
                 #parsed_machine_config_transition{
-                    read = "?",
-                    to_state = "cocorico",
-                    write = "*",
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
                     action = left
                 }
             ],
-            "sub" => [
+            "subone" => [
                 % Below duplcation on `"read":"."` is voluntary error, as you can see it will not achieve to validate this data as
                 % above one is already failing
                 #parsed_machine_config_transition{
@@ -250,9 +250,16 @@ validate_machine_transitions_several_duplicated_error_test() ->
                     action = right
                 },
                 #parsed_machine_config_transition{
-                    read = "?",
-                    to_state = "cocorico",
-                    write = "*",
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ]
+        },
+        get_valid_states(),
+        get_valid_alphabet()
+    ).
                     action = left
                 }
             ]

--- a/test/machine_validator_test.erl
+++ b/test/machine_validator_test.erl
@@ -260,6 +260,101 @@ validate_machine_transitions_several_duplicated_error_test() ->
         get_valid_states(),
         get_valid_alphabet()
     ).
+
+validate_machine_transitions_not_alphabet_read_test() ->
+    {error, "skip", {"read", {expected_alphabet_character, "not_alphabet_character"}}} = machine_validator:validate_machine_transitions(
+        #{
+            "scanright" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ],
+            "skip" => [
+                #parsed_machine_config_transition{
+                    read = "not_alphabet_character",
+                    to_state = "scanright",
+                    % Below error is voluntary, as it verifies that validator will
+                    % Look at read first
+                    write = "also_not_alphabet_character",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ],
+            "subone" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ]
+        },
+        get_valid_states(),
+        get_valid_alphabet()
+    ).
+
+validate_machine_transitions_not_alphabet_write_test() ->
+    {error, "scanright", {"write", {expected_alphabet_character, "not_alphabet_character"}}} = machine_validator:validate_machine_transitions(
+        #{
+            "skip" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ],
+            "scanright" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = "=",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "=",
+                    to_state = "subone",
+                    write = "not_alphabet_character",
+                    action = left
+                }
+            ],
+            "subone" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
                     action = left
                 }
             ]

--- a/test/machine_validator_test.erl
+++ b/test/machine_validator_test.erl
@@ -69,3 +69,12 @@ validate_machine_finals_several_expected_states_entry_error_test() ->
     {error, {expected_states, ["invalid_state_entry_0", "invalid_state_entry_1"]}} = machine_validator:validate_machine_finals(
         ["HALT", "invalid_state_entry_0", "invalid_state_entry_1"], get_valid_states()
     ).
+
+% Validate Initial
+validate_machine_initial_test() ->
+    ok = machine_validator:validate_machine_initial("scanright", get_valid_states()).
+
+validate_machine_initial_expected_state_error_test() ->
+    {error, {expected_states, "invalid_state"}} = machine_validator:validate_machine_initial(
+        "invalid_state", get_valid_states()
+    ).

--- a/test/machine_validator_test.erl
+++ b/test/machine_validator_test.erl
@@ -1,5 +1,7 @@
 -module(machine_validator_test).
 
+-include("../src/machine.hrl").
+
 -include_lib("eunit/include/eunit.hrl").
 
 get_valid_alphabet() ->
@@ -18,6 +20,52 @@ get_valid_states() ->
         "skip",
         "HALT"
     ].
+
+get_valid_transitions_map() ->
+    #{
+        "abs" => [
+            #parsed_machine_config_transition{
+                read = ".",
+                to_state = "scanright",
+                write = ".",
+                action = right
+            },
+            #parsed_machine_config_transition{
+                read = "?",
+                to_state = "cocorico",
+                write = "*",
+                action = left
+            }
+        ],
+        "add" => [
+            #parsed_machine_config_transition{
+                read = ".",
+                to_state = "scanright",
+                write = ".",
+                action = right
+            },
+            #parsed_machine_config_transition{
+                read = "?",
+                to_state = "cocorico",
+                write = "*",
+                action = left
+            }
+        ],
+        "sub" => [
+            #parsed_machine_config_transition{
+                read = ".",
+                to_state = "scanright",
+                write = ".",
+                action = right
+            },
+            #parsed_machine_config_transition{
+                read = "?",
+                to_state = "cocorico",
+                write = "*",
+                action = left
+            }
+        ]
+    }.
 
 % Validate Alphabet
 validate_machine_alphabet_test() ->
@@ -77,4 +125,138 @@ validate_machine_initial_test() ->
 validate_machine_initial_expected_state_error_test() ->
     {error, {expected_states, "invalid_state"}} = machine_validator:validate_machine_initial(
         "invalid_state", get_valid_states()
+    ).
+
+% Validate transitions
+validate_machine_transitions_test() ->
+    ok = machine_validator:validate_machine_transitions(
+        get_valid_transitions_map(),
+        get_valid_states(),
+        get_valid_alphabet()
+    ).
+
+validate_machine_transitions_duplicated_error_test() ->
+    {error, "sub", {duplicated_elements, ["."]}} = machine_validator:validate_machine_transitions(
+        #{
+            "abs" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "?",
+                    to_state = "cocorico",
+                    write = "*",
+                    action = left
+                }
+            ],
+            "add" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "?",
+                    to_state = "cocorico",
+                    write = "*",
+                    action = left
+                }
+            ],
+            "sub" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "?",
+                    to_state = "cocorico",
+                    write = "*",
+                    action = left
+                }
+            ]
+        },
+        get_valid_states(),
+        get_valid_alphabet()
+    ).
+
+validate_machine_transitions_several_duplicated_error_test() ->
+    {error, "add", {duplicated_elements, [".", "?"]}} = machine_validator:validate_machine_transitions(
+        #{
+            "abs" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "?",
+                    to_state = "cocorico",
+                    write = "*",
+                    action = left
+                }
+            ],
+            "add" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "?",
+                    to_state = "cocorico",
+                    write = "*",
+                    action = left
+                },
+                #parsed_machine_config_transition{
+                    read = "?",
+                    to_state = "cocorico",
+                    write = "*",
+                    action = left
+                }
+            ],
+            "sub" => [
+                % Below duplcation on `"read":"."` is voluntary error, as you can see it will not achieve to validate this data as
+                % above one is already failing
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "?",
+                    to_state = "cocorico",
+                    write = "*",
+                    action = left
+                }
+            ]
+        },
+        get_valid_states(),
+        get_valid_alphabet()
     ).

--- a/test/machine_validator_test.erl
+++ b/test/machine_validator_test.erl
@@ -123,7 +123,7 @@ validate_machine_initial_test() ->
     ok = machine_validator:validate_machine_initial("scanright", get_valid_states()).
 
 validate_machine_initial_expected_state_error_test() ->
-    {error, {expected_states, "invalid_state"}} = machine_validator:validate_machine_initial(
+    {error, {expected_state, "invalid_state"}} = machine_validator:validate_machine_initial(
         "invalid_state", get_valid_states()
     ).
 
@@ -262,7 +262,7 @@ validate_machine_transitions_several_duplicated_error_test() ->
     ).
 
 validate_machine_transitions_not_alphabet_read_test() ->
-    {error, "skip", {"read", {expected_alphabet_character, "not_alphabet_character"}}} = machine_validator:validate_machine_transitions(
+    {error, "skip", {read, {expected_alphabet_character, "not_alphabet_character"}}} = machine_validator:validate_machine_transitions(
         #{
             "scanright" => [
                 #parsed_machine_config_transition{
@@ -314,7 +314,7 @@ validate_machine_transitions_not_alphabet_read_test() ->
     ).
 
 validate_machine_transitions_not_alphabet_write_test() ->
-    {error, "scanright", {"write", {expected_alphabet_character, "not_alphabet_character"}}} = machine_validator:validate_machine_transitions(
+    {error, "scanright", {write, {expected_alphabet_character, "not_alphabet_character"}}} = machine_validator:validate_machine_transitions(
         #{
             "skip" => [
                 #parsed_machine_config_transition{
@@ -341,6 +341,158 @@ validate_machine_transitions_not_alphabet_write_test() ->
                     read = "=",
                     to_state = "subone",
                     write = "not_alphabet_character",
+                    action = left
+                }
+            ],
+            "subone" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ]
+        },
+        get_valid_states(),
+        get_valid_alphabet()
+    ).
+
+validate_machine_transitions_invalid_key_error_test() ->
+    {error, {expected_states, ["invalid_state_transition_key"]}} = machine_validator:validate_machine_transitions(
+        #{
+            "subone" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ],
+            "scanright" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = "=",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "=",
+                    to_state = "subone",
+                    write = ".",
+                    action = left
+                }
+            ],
+            "invalid_state_transition_key" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ]
+        },
+        get_valid_states(),
+        get_valid_alphabet()
+    ).
+
+validate_machine_transitions_several_invalid_key_error_test() ->
+    {error,
+        {expected_states, ["also_invalid_state_transition_key", "invalid_state_transition_key"]}} = machine_validator:validate_machine_transitions(
+        #{
+            "also_invalid_state_transition_key" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ],
+            "scanright" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = "=",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "=",
+                    to_state = "subone",
+                    write = ".",
+                    action = left
+                }
+            ],
+            "invalid_state_transition_key" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ]
+        },
+        get_valid_states(),
+        get_valid_alphabet()
+    ).
+
+validate_machine_transitions_invalid_to_state_error_test() ->
+    % Note: Erlang looks like iterating over map keys via their ascii value, then here scanright is verified first
+    {error, "scanright", {to_state, {expected_state, "invalid_to_state"}}} = machine_validator:validate_machine_transitions(
+        #{
+            "subone" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = ".",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "-",
+                    to_state = "subone",
+                    write = "=",
+                    action = left
+                }
+            ],
+            "scanright" => [
+                #parsed_machine_config_transition{
+                    read = ".",
+                    to_state = "scanright",
+                    write = "=",
+                    action = right
+                },
+                #parsed_machine_config_transition{
+                    read = "=",
+                    to_state = "invalid_to_state",
+                    write = ".",
                     action = left
                 }
             ],


### PR DESCRIPTION
# This PR covers the following machine config fields validation:
- initial
- transitions

## Reminder: ( from related to #16 )
### Rules
### Initial
- [x] initial state **must** be in state list

Transitions:
- [x] duplicates are forbidden in transitions list `{ "a": [{ "read": "X" }, { "read": "X" }] }`
- [x] each read character **must** be defined in alphabet
- [x] each write character **must** be defined in alphabet
- [x] each to_state **must** be defined in state list
- [x] all keys of transition dictionary **must** be defined in state list


## Still need to be done:
- Machine config validation format_error handler + unit tests
- Machine config validation usage inside main + integ tests