### PR TITLE
Disable controls when they can not be used

### DIFF
--- a/viz/src/App.vue
+++ b/viz/src/App.vue
@@ -5,7 +5,7 @@ import {
   ArrowNarrowRightIcon,
   CheckIcon,
   XCircleIcon,
-  XIcon
+  XIcon,
 } from "@heroicons/vue/solid";
 import TheTape from "./components/TheTape.vue";
 import { vizMachine } from "./machines/viz";
@@ -17,6 +17,14 @@ import AppBadge from "./components/AppBadge.vue";
 const { state, send } = useMachine(vizMachine);
 const indexOnStepList = computed(() => state.value.context.stepIndex);
 const playingStatus = computed<PlayingStatus>(() => {
+  if (
+    state.value.matches(
+      "Application is ready.Managing visualizer execution.Idle"
+    )
+  ) {
+    return "not-started";
+  }
+
   if (
     state.value.matches(
       "Application is ready.Managing visualizer execution.Playing steps.Automatic playing off"
@@ -233,7 +241,9 @@ const { state: submitButtonState, send: submitButtonSend } = useActor(
 
                       <div class="mt-2 text-sm text-red-700">
                         <ul role="list" class="pl-5 space-y-1 list-disc">
-                          <li class="whitespace-pre-line">{{ errorToDisplay }}</li>
+                          <li class="whitespace-pre-line">
+                            {{ errorToDisplay }}
+                          </li>
                         </ul>
                       </div>
                     </div>

--- a/viz/src/components/TheTape.vue
+++ b/viz/src/components/TheTape.vue
@@ -26,7 +26,7 @@ interface TapeStepWithKeyForEachSquare extends Omit<TapeStep, "tape"> {
 const EMPTY_STEP: TapeStep = {
   currentState: "None",
   indexOnTape: 0,
-  status: "blocked",
+  status: "none",
   tape: ["-"],
 };
 
@@ -57,7 +57,10 @@ const addedBlankSpace = squaresAmountOnOneSideOfHead;
  * We add enough blank squares to all steps so that
  * there will always be the same amount of squares on the tape.
  */
-function fillStepsWithBlankSpacesOnSides(steps: TapeStep[], blank: string): TapeStep[] {
+function fillStepsWithBlankSpacesOnSides(
+  steps: TapeStep[],
+  blank: string
+): TapeStep[] {
   return steps.map(({ tape, ...props }) => ({
     tape: [
       ...Array.from({ length: addedBlankSpace }).map(() => blank),
@@ -69,7 +72,10 @@ function fillStepsWithBlankSpacesOnSides(steps: TapeStep[], blank: string): Tape
 }
 
 const steps = computed(() =>
-  fillStepsWithBlankSpacesOnSides(props.steps ?? [EMPTY_STEP], props.blankCharacter ?? "-")
+  fillStepsWithBlankSpacesOnSides(
+    props.steps ?? [EMPTY_STEP],
+    props.blankCharacter ?? "-"
+  )
 );
 
 function computeTapeListWithFixedKeys(steps: TapeStep[]) {
@@ -125,6 +131,7 @@ const stateOfExecutionBadgeStatus = computed(() => {
     continue: "pending",
     blocked: "error",
     final: "success",
+    none: "error",
   };
 
   return badgeStatus[stateOfExecution.value];
@@ -134,10 +141,16 @@ const prettyStateOfExecution = computed(() => {
     continue: "Running",
     blocked: "Blocked",
     final: "Reached final state",
+    none: "Not loaded",
   };
 
   return prettyNames[stateOfExecution.value];
 });
+const disablePlayingControls = computed(
+  () =>
+    props.playingStatus === "disabled" || props.playingStatus === "not-started"
+);
+const disableRestartControl = computed(() => props.playingStatus !== "disabled");
 
 const displayedTape = computed(() => {
   return tape.value.slice(
@@ -222,7 +235,7 @@ function handleAutomaticPlayingDelayMode() {
 
       <div class="flex items-center mx-auto space-x-6">
         <button
-          :disabled="playingStatus === 'disabled'"
+          :disabled="disablePlayingControls"
           :aria-label="playingStatus === 'playing' ? 'Pause' : 'Play'"
           @click="handlePlayPauseButtonClick"
           class="flex items-center justify-center w-10 h-10 rounded-full"
@@ -235,6 +248,7 @@ function handleAutomaticPlayingDelayMode() {
         </button>
 
         <button
+          :disabled="disablePlayingControls"
           aria-label="Go to next step"
           @click="props.onNextStep"
           class="flex items-center justify-center w-8 h-8 rounded-full"
@@ -268,6 +282,7 @@ function handleAutomaticPlayingDelayMode() {
         </button>
 
         <button
+          :disabled="disableRestartControl"
           aria-label="Restart execution"
           @click="props.onResetSteps"
           class="flex items-center justify-center w-8 h-8 rounded-full"

--- a/viz/src/types.ts
+++ b/viz/src/types.ts
@@ -1,4 +1,4 @@
-export type StatusOfExecution = "continue" | "blocked" | "final";
+export type StatusOfExecution = "continue" | "blocked" | "final" | "none";
 
 export interface TapeStep {
   currentState: string;
@@ -14,4 +14,4 @@ export interface MachineExecution {
 
 export type AutomaticPlayingDelayMode = "MEDIUM" | "FAST";
 
-export type PlayingStatus = "playing" | "paused" | "disabled";
+export type PlayingStatus = "playing" | "paused" | "disabled" | "not-started";


### PR DESCRIPTION
We also improved the status of the visualizer when a machine has not been loaded yet.